### PR TITLE
Fix to spark shuffle service link

### DIFF
--- a/install-spark2/install-spark2-v01.sh
+++ b/install-spark2/install-spark2-v01.sh
@@ -19,7 +19,7 @@ rm -r "$SPARK_DIR"
 mv "$newspark" "$SPARK_DIR"
 
 # Create symlinks
-sudo ln -s "$SPARK_DIR/yarn/spark-2.0.0-yarn-shuffle.jar" \
+sudo ln -sfn "$SPARK_DIR/yarn/spark-2.0.0-yarn-shuffle.jar" \
    "$HADOOP_DIR/lib/spark-yarn-shuffle.jar"
 sudo ln -s $HADOOP_DIR /usr/hdp/current/hadoop
 sudo ln -s $HADOOP_YARN_DIR /usr/hdp/current/hadoop-yarn   


### PR DESCRIPTION
When symbolic link is already present script action fails to update it, which results in failure of node managers whenever they need to restart. This fixes this issue.
